### PR TITLE
feat: create docker image for linux/amd64 and linux/arm64 platforms

### DIFF
--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -38,14 +38,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
+      - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/openclarity/vmclarity-tools-base:${{ inputs.image_tag }}
-          file: Dockerfile
           push: ${{ inputs.push }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:20.04 AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ubuntu:20.04 AS builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 RUN apt-get update && apt-get install -y curl
 
@@ -28,7 +31,7 @@ RUN tar xzvf lynis_3.0.8.tar.gz
 # install chkrootkit
 RUN tar xzvf chkrootkit-0.57.tar.gz
 
-FROM alpine:3.17
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.17
 
 RUN apk upgrade
 RUN apk add clamav

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,13 @@ help: ## This help.
 .PHONY: docker
 docker: ## Build Docker image
 	@(echo "Building docker image...")
-	docker build --file ./Dockerfile --build-arg VERSION=${VERSION} \
+	docker build \
+		--file ./Dockerfile \
+		--build-arg VERSION=${VERSION} \
 		--build-arg BUILD_TIMESTAMP=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
 		--build-arg COMMIT_HASH=$(shell git rev-parse HEAD) \
-		-t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+		-t ${DOCKER_IMAGE}:${DOCKER_TAG} \
+		.
 
 
 .PHONY: push-docker


### PR DESCRIPTION
## Description

With this PR the docker image will be created not only for linux/amd64 but for linux/arm64 as well.
This is the prerequisite of running docker locally as a next provider type and have E2E tests in VMClarity.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
