### PR TITLE
add openssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ FROM alpine:3.17
 
 RUN apk upgrade
 RUN apk add clamav
+RUN apk add openssh
 
 WORKDIR /artifacts
 


### PR DESCRIPTION
## Description

Part of https://github.com/openclarity/vmclarity/issues/549 we need to have `ssh-keygen` installed on the cli tools base

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

