### PR TITLE
fix: missing binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ RUN apk upgrade --no-cache --quiet
 RUN apk add --no-cache clamav
 RUN apk add --no-cache yara --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
 RUN apk add --no-cache openssh
+RUN apk add --no-cache git  # required by gitleaks
+RUN apk add --no-cache grep # required by lynis
 
 COPY --from=gitleaks ["/artifacts/gitleaks", "./gitleaks"]
 COPY --from=lynis ["/artifacts/lynis", "./lynis"]


### PR DESCRIPTION
## Description

Install missing binaries:
* `git` required by `gitleaks`
* GNU `grep` required by `lynis`

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
